### PR TITLE
Make it explicit that this module is compatible with Puppet 5

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -43,11 +43,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     },
     {
       "name": "puppet",
-      "version_requirement": "3.x"
+      "version_requirement": ">= 3.0.0 < 6.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
Without this change Kafo-based installers need to be forced to load this module
with --skip-puppet-version-check. Other software that parses version
requirements in metadata.json may have similar issues.